### PR TITLE
Switch (<>) to be right-biased

### DIFF
--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -81,7 +81,7 @@ instance showMap :: (Show k, Show v) => Show (Map k v) where
   show m = "(fromFoldable " <> show (toAscArray m) <> ")"
 
 instance semigroupMap :: Ord k => Semigroup (Map k v) where
-  append = union
+  append = unionWith (\_ x -> x)
 
 instance monoidMap :: Ord k => Monoid (Map k v) where
   mempty = empty

--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -176,6 +176,10 @@ mapTests = do
             groupBy ((==) `on` fst) <<< sortBy (compare `on` fst) in
     M.fromFoldableWith (<>) arr === f (arr :: List (Tuple String String))
 
+  log "fromFoldable (a <> b) = fromFoldable a <> fromFoldable b, for arrays a, b"
+  quickCheck $ \a b ->
+    M.fromFoldable (a <> b) === M.fromFoldable a <> M.fromFoldable (b :: Array (Tuple String String))
+
   log "toUnfoldable is sorted"
   quickCheck $ \(TestMap m) ->
     let list = M.toUnfoldable (m :: M.Map SmallKey Int)


### PR DESCRIPTION
First part of #2.

This is technically non-breaking. The documentation does not claim that `<>` is `union`.