### PR TITLE
Add Map.applyWithDefaults to satisfy Applicative laws

### DIFF
--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -5,7 +5,7 @@ module Data.Map
 
 import Prelude
 
-import Data.Map.Internal (Map, alter, checkValid, delete, empty, filter, filterKeys, filterWithKey, findMax, findMin, foldSubmap, fromFoldable, fromFoldableWith, insert, isEmpty, isSubmap, lookup, lookupGE, lookupGT, lookupLE, lookupLT, member, pop, showTree, singleton, size, submap, toUnfoldable, toUnfoldableUnordered, union, unionWith, unions, update, values)
+import Data.Map.Internal (Map, alter, applyWithDefault, checkValid, delete, empty, filter, filterKeys, filterWithKey, findMax, findMin, foldSubmap, fromFoldable, fromFoldableWith, insert, isEmpty, isSubmap, lookup, lookupGE, lookupGT, lookupLE, lookupLT, member, pop, showTree, singleton, size, submap, toUnfoldable, toUnfoldableUnordered, union, unionWith, unions, update, values)
 import Data.Set (Set)
 import Unsafe.Coerce (unsafeCoerce)
 

--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -342,23 +342,23 @@ mapTests = do
 
   -- Identity: (pure identity) <*> v = v
   log "applyWithDefault abides applicative laws: Identity"
-  quickCheck \(TestMap x :: TestMap Int Int) ->
-    let out = M.applyWithDefault M.empty (Just identity) x Nothing
+  quickCheck \(TestMap x :: TestMap Int Int) (d :: Maybe Int) ->
+    let out = M.applyWithDefault M.empty (Just identity) x d
     in out == x
 
   -- Composition: pure (<<<) <*> f <*> g <*> h = f <*> (g <*> h)
   log "applyWithDefault abides applicative laws: Composition"
-  quickCheck \(TestMap f :: TestMap Int (Boolean -> String -> Int))
+  quickCheck \(TestMap f :: TestMap Boolean (Int -> String))
               fd
-              (TestMap g :: TestMap Int Boolean)
+              (TestMap g :: TestMap Boolean (Boolean -> Int))
               gd
-              (TestMap h :: TestMap Int String)
+              (TestMap h :: TestMap Boolean Boolean)
               hd ->
-    let left0 = M.applyWithDefault M.empty (Just identity) f fd
-        left1 = M.applyWithDefault left0 fd g gd
-        left2 = M.applyWithDefault left1 (fd <*> gd) h hd
-        right0 = M.applyWithDefault f fd g gd
-        right1 = M.applyWithDefault right0 (fd <*> gd) h hd
+    let left0 = M.applyWithDefault M.empty (Just (<<<)) f fd
+        left1 = M.applyWithDefault left0 (Just (<<<) <*> fd) g gd
+        left2 = M.applyWithDefault left1 (Just (<<<) <*> fd <*> gd) h hd
+        right0 = M.applyWithDefault g gd h hd
+        right1 = M.applyWithDefault f fd right0 (gd <*> hd)
     in left2 == right1
 
   --Homomorphism: (pure f) <*> (pure x) = pure (f x)


### PR DESCRIPTION
Inspired by @joneshf's comments here: https://github.com/purescript-contrib/purescript-these/issues/21

This gives us a way of modelling an applicative map, for example something like:

```purescript
data DefaultMap k v = DefaultMap (M.Map k v) (Maybe v)

default :: forall k v . Maybe v -> DefaultMap k v
default = DefaultMap M.empty

empty :: forall k v . DefaultMap k v
empty = default Nothing

lookup :: forall k v . Ord k => k -> DefaultMap k v -> Maybe v
lookup k (DefaultMap m d) = M.lookup k m <|> d

derive instance functorDefaultMap :: Functor (DefaultMap k)

instance applyDefaultMap :: Ord k => Apply (DefaultMap k) where
  apply (DefaultMap lm ld) (DefaultMap rm rd) =
    DefaultMap (M.applyWithDefault lm ld rm rd) (ld <*> rd)

instance applicativeDefaultMap :: Ord k => Applicative (DefaultMap k) where
  pure = default <<< Just
```

Whether or not the above should live in this library is a different question (thoughts?), but the function is useful nonetheless.