### PR TITLE
Add Semiring Set instance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "purescript-quickcheck": "^5.0.0",
     "purescript-minibench": "^2.0.0",
     "purescript-console": "^4.0.0",
-    "purescript-assert": "^4.0.0"
+    "purescript-assert": "^4.0.0",
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/test/Test/Data/Set.purs
+++ b/test/Test/Data/Set.purs
@@ -42,3 +42,8 @@ setTests = do
 
      log "- distributivity"
      assert $ s1 * (s2 + s3) == (s1 * s2) + (s1 * s3)
+     assert $ (s1 + s2) * s3 == (s1 * s3) + (s2 * s3)
+
+     log "- annihilation"
+     assert $ zero * s1 == zero
+     assert $ s1 * zero == zero

--- a/test/Test/Data/Set.purs
+++ b/test/Test/Data/Set.purs
@@ -25,3 +25,20 @@ setTests = do
          s2 = S.fromFoldable [2,4,6,8,10]
          s3 = S.fromFoldable [2,4]
      assert $ S.intersection s1 s2 == s3
+
+  log "semiring"
+  do let s1 = S.fromFoldable ["a", "b", "c"]
+         s2 = S.fromFoldable ["d", "e"]
+         s3 = S.fromFoldable ["f", "g", "h", "i"]
+     log "- commutative monoid under addition"
+     assert $ s1 + s2 == s2 + s1
+     assert $ s1 + (s2 + s3) == (s1 + s2) + s3
+     assert $ s1 + zero == s1
+
+     log "- monoid under multiplication"
+     assert $ s1 * one == s1
+     assert $ one * s1 == s1
+     assert $ s1 * (s2 * s3) == (s1 * s2) * s3
+
+     log "- distributivity"
+     assert $ s1 * (s2 + s3) == (s1 * s2) + (s1 * s3)


### PR DESCRIPTION
See discussion in https://github.com/purescript/purescript-semirings/issues/11#issue-404086220

I'm not aware of any other way of giving `Set` a `Semiring` instance, and while it is arguably a little arcane, I think these are both useful operations on sets (of course we already had `union`, but we don't have set-wise multiplication).