### PR TITLE
Plus and Apply instances for Map

### DIFF
--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -48,6 +48,8 @@ module Data.Map.Internal
 
 import Prelude
 
+import Control.Alt (class Alt)
+import Control.Plus (class Plus)
 import Data.Eq (class Eq1)
 import Data.Foldable (foldl, foldMap, foldr, class Foldable)
 import Data.FoldableWithIndex (class FoldableWithIndex, foldlWithIndex, foldrWithIndex)
@@ -148,6 +150,14 @@ instance traversableWithIndexMap :: TraversableWithIndex k (Map k) where
           <*> pure k2
           <*> f k2 v2
           <*> traverseWithIndex f right
+
+instance altMap :: Ord k => Alt (Map k)
+  where
+  alt = union
+
+instance plusMap :: Ord k => Plus (Map k)
+  where
+  empty = empty
 
 -- | Render a `Map` as a `String`
 showTree :: forall k v. Show k => Show v => Map k v -> String

--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -151,6 +151,12 @@ instance traversableWithIndexMap :: TraversableWithIndex k (Map k) where
           <*> f k2 v2
           <*> traverseWithIndex f right
 
+instance applyMap :: Ord k => Apply (Map k)
+  where
+  apply = applyFromLiftA2 intersectionWith
+    where
+    applyFromLiftA2 liftA2 = liftA2 identity
+
 instance altMap :: Ord k => Alt (Map k)
   where
   alt = union


### PR DESCRIPTION
I think it would also be `Alternative`, except that `Alternative` demands `Applicative` instead of just `Apply`. I can't actually see a good reason for this, given that the laws don't seem to mention `pure` at all.