### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -68,6 +68,8 @@ data Map k v
   | Two (Map k v) k v (Map k v)
   | Three (Map k v) k v (Map k v) k v (Map k v)
 
+type role Map nominal representational
+
 -- Internal use
 toAscArray :: forall k v. Map k v -> Array (Tuple k v)
 toAscArray = toUnfoldable


### PR DESCRIPTION
This prevents terms of type `Map k1 a` to be coerced to type `Map k2 a` but allows terms of type `Map k a` to be coerced to type `Map k b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes in maps for instance.

Coercing between two arbitrary key types would be unsafe because it can change the result of a program (modulo newtypes):

```
> import Data.Map
> import Data.Map as Map
> import Data.Ord.Down
> import Data.Tuple
> import Safe.Coerce
>
> occurences = Map.fromFoldable [Tuple "a" 0, Tuple "b" 0]
>
> Map.insert (Down "c") 0 (coerce occurences) :: Map (Down String) Int
(fromFoldable [(Tuple (Down "c") 0),(Tuple (Down "a") 0),(Tuple (Down "b") 0)])
>
> coerce (Map.insert "c" 0 occurences) :: Map (Down String) Int
(fromFoldable [(Tuple (Down "a") 0),(Tuple (Down "b") 0),(Tuple (Down "c") 0)])
```