### PR TITLE
Remove fold1 from the Foldable1 instance for NonEmptySet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.0-rc3"
+          purescript: "0.14.0-rc5"
 
       - uses: actions/setup-node@v1
         with:

--- a/src/Data/Set/NonEmpty.purs
+++ b/src/Data/Set/NonEmpty.purs
@@ -52,7 +52,6 @@ derive newtype instance foldableNonEmptySet :: Foldable NonEmptySet
 
 instance foldable1NonEmptySet :: Foldable1 NonEmptySet where
   foldMap1 f = foldMap1 f <<< (toUnfoldable1 :: forall a. NonEmptySet a -> NonEmptyList a)
-  fold1 = foldMap1 identity
   foldr1 f = foldr1 f <<< (toUnfoldable1 :: forall a. NonEmptySet a -> NonEmptyList a)
   foldl1 f = foldl1 f <<< (toUnfoldable1 :: forall a. NonEmptySet a -> NonEmptyList a)
 


### PR DESCRIPTION
We removed the fold1 method of Foldable1 in https://github.com/purescript/purescript-foldable-traversable/pull/128.