### PR TITLE
Idiomatic Show instances for sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 - Added support for PureScript 0.14 and dropped support for all previous versions (#35, #43)
-- Drop `Map`'s `Semigroup` and `Monoid` instances and provide unbiased instances via `SemigroupMap` newtype (#38)
+- Dropped `Map`'s `Semigroup` and `Monoid` instances and provide unbiased instances via a `SemigroupMap` newtype instead (#38)
+- Updated the `Show` instances for (non empty) sets (#46)
 
 New features:
 - Added `Apply` instance for `Map` (#16)

--- a/src/Data/Set.purs
+++ b/src/Data/Set.purs
@@ -71,7 +71,7 @@ instance eq1Set :: Eq1 Set where
   eq1 = eq
 
 instance showSet :: Show a => Show (Set a) where
-  show s = "(fromFoldable " <> show (toList s) <> ")"
+  show s = "(fromFoldable " <> show (toUnfoldable s :: Array a) <> ")"
 
 instance ordSet :: Ord a => Ord (Set a) where
   compare s1 s2 = compare (toList s1) (toList s2)

--- a/src/Data/Set/NonEmpty.purs
+++ b/src/Data/Set/NonEmpty.purs
@@ -26,6 +26,7 @@ module Data.Set.NonEmpty
 
 import Prelude hiding (map)
 
+import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Eq (class Eq1)
 import Data.Foldable (class Foldable)
 import Data.List (List, (:))
@@ -56,7 +57,7 @@ instance foldable1NonEmptySet :: Foldable1 NonEmptySet where
   foldl1 f = foldl1 f <<< (toUnfoldable1 :: forall a. NonEmptySet a -> NonEmptyList a)
 
 instance showNonEmptySet :: Show a => Show (NonEmptySet a) where
-  show s = "(fromFoldable1 " <> show (toUnfoldable1 s :: NonEmptyList a) <> ")"
+  show s = "(fromFoldable1 " <> show (toUnfoldable1 s :: NonEmptyArray a) <> ")"
 
 -- | Create a set with one element.
 singleton :: forall a. a -> NonEmptySet a


### PR DESCRIPTION
**Description of the change**

This pull request changes the output of show for Data.Set.Set and Data.Set.NonEmpty.NonEmptySet from this:

```purs
> Data.Set.fromFoldable [0, 1]
(fromFoldable (0 : 1 : Nil))

> Data.Set.NonEmpty.fromFoldable [0, 1]
(Just (fromFoldable1 (NonEmptyList (NonEmpty 0 (1 : Nil)))))
```

to that:

```purs
> Data.Set.fromFoldable [0, 1]
(fromFoldable [0,1])

> Data.Set.NonEmpty.fromFoldable [0, 1]
(Just (fromFoldable1 (NonEmptyArray [0,1])))
```

for consistency with the Show instances for maps and (non empty) lazy lists, which show arrays instead of lists for conciseness.

Close https://github.com/purescript/purescript-ordered-collections/issues/39.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
