### PR TITLE
Add `toggle` for Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `toggle` for `Set`
 
 Bugfixes:
 

--- a/src/Data/Set.purs
+++ b/src/Data/Set.purs
@@ -15,6 +15,7 @@ module Data.Set
   , insert
   , member
   , delete
+  , toggle
   , size
   , findMin
   , findMax
@@ -44,7 +45,7 @@ import Data.Foldable (class Foldable, foldMap, foldl, foldr)
 import Data.List (List)
 import Data.List as List
 import Data.Map.Internal as M
-import Data.Maybe (Maybe, maybe)
+import Data.Maybe (Maybe(..), maybe)
 import Data.Ord (class Ord1)
 import Data.Unfoldable (class Unfoldable)
 import Partial.Unsafe (unsafePartial)
@@ -127,6 +128,10 @@ insert a (Set m) = Set (M.insert a unit m)
 -- | Delete a value from a set
 delete :: forall a. Ord a => a -> Set a -> Set a
 delete a (Set m) = Set (a `M.delete` m)
+
+-- | Insert a value into a set if it is not already present, if it is present, delete it.
+toggle :: forall a. Ord a => a -> Set a -> Set a
+toggle a (Set m) = Set (M.alter (maybe (Just unit) (\_ -> Nothing)) a m)
 
 -- | Find the size of a set
 size :: forall a. Set a -> Int

--- a/test/Test/Data/Set.purs
+++ b/test/Test/Data/Set.purs
@@ -31,3 +31,9 @@ setTests = do
   do let s1 = S.fromFoldable [Just 1,Just 2,Just 3,Nothing]
          s2 = S.fromFoldable [1,2,3]
      assert $ S.catMaybes s1 == s2
+
+  log "toggle - inserts item"
+  assert $ S.toggle 1 S.empty == S.fromFoldable [1]
+
+  log "toggle - deletes item"
+  assert $ S.toggle 1 (S.fromFoldable [1]) == S.empty


### PR DESCRIPTION
**Description of the change**

Adds a function `toggle` for `Set`.

If the passed value is missing from the set, adds it.
If the passed value exists in the set, deletes it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
