### PR TITLE
Added more efficient `unionWith`, eliminate transformation `Map` to `List` in `Foldable{WithIndex}` instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 New features:
 - Exported `Data.Map.Internal` data constructors (#52 by @natefaubion)
 - Add unbiased `Semigroup`/`Monoid` instances to `Map` with `Warn` (#54 by @JordanMartinez)
+- Improved speed of `foldr`, `foldl`, `foldMap`, `foldlWithIndex`, `foldrWithIndex`, `foldMapWithIndex`, `unionWith` (#60 by @xgrommx)
 
 Bugfixes:
 

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -80,41 +80,43 @@ benchMap = do
         natPairs = (\x -> Tuple x x) <$> nats
         bigMap = OldMap.fromFoldable $ natPairs
         bigMap' = M.fromFoldable $ natPairs
+        size = OldMap.size bigMap
+        size' = M.size bigMap'
 
-    log $ "OldMap.foldr big map (" <> show (OldMap.size bigMap) <> ")"
+    log $ "OldMap.foldr big map (" <> show size <> ")"
     benchWith 10 \_ -> F.foldr (+) 0 bigMap
 
-    log $ "M.foldr big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.foldr big map (" <> show size' <> ")"
     benchWith 10 \_ -> F.foldr (+) 0 bigMap'
 
-    log $ "OldMap.foldl big map (" <> show (OldMap.size bigMap) <> ")"
+    log $ "OldMap.foldl big map (" <> show size <> ")"
     benchWith 10 \_ -> F.foldl (+) 0 bigMap
 
-    log $ "M.foldl big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.foldl big map (" <> show size' <> ")"
     benchWith 10 \_ -> F.foldl (+) 0 bigMap'
 
-    log $ "OldMap.foldMap big map (" <> show (OldMap.size bigMap) <> ")"
+    log $ "OldMap.foldMap big map (" <> show size <> ")"
     benchWith 10 \_ -> F.foldMap Additive bigMap
 
-    log $ "M.foldMap big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.foldMap big map (" <> show size' <> ")"
     benchWith 10 \_ -> F.foldMap Additive bigMap'
 
-    log $ "OldMap.foldrWithIndex big map (" <> show (OldMap.size bigMap) <> ")"
+    log $ "OldMap.foldrWithIndex big map (" <> show size <> ")"
     benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap
 
-    log $ "M.foldrWithIndex big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.foldrWithIndex big map (" <> show size' <> ")"
     benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap'
 
-    log $ "OldMap.foldlWithIndex big map (" <> show (OldMap.size bigMap) <> ")"
+    log $ "OldMap.foldlWithIndex big map (" <> show size <> ")"
     benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap
 
-    log $ "M.foldlWithIndex big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.foldlWithIndex big map (" <> show size' <> ")"
     benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap'
 
-    log $ "OldMap.foldMapWithIndex big map (" <> show (OldMap.size bigMap) <> ")"
+    log $ "OldMap.foldMapWithIndex big map (" <> show size <> ")"
     benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap
 
-    log $ "M.foldMapWithIndex big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.foldMapWithIndex big map (" <> show size' <> ")"
     benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap'
 
   benchFromFoldable = do

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -4,10 +4,14 @@ import Prelude
 
 import Data.List as L
 import Data.Map as M
+import Bench.OldMap as OldMap
+import Data.Foldable as F
+import Data.FoldableWithIndex as FI
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Console (log)
 import Performance.Minibench (bench, benchWith)
+import Data.Monoid.Additive (Additive(..))
 
 benchMap :: Effect Unit
 benchMap = do
@@ -21,7 +25,35 @@ benchMap = do
   log "------------"
   benchFromFoldable
 
+  log ""
+
+  log "Foldable"
+  log "---------------"
+  benchFoldable
+
+  log ""
+
+  log "union"
+  log "---------------"
+  benchUnion
+
   where
+
+  benchUnion = do
+    let nats = L.range 0 999999
+        nats2 = L.range 999999 1999999
+        natPairs = (flip Tuple) unit <$> nats
+        natPairs2 = (flip Tuple) unit <$> nats2
+        bigMap = OldMap.fromFoldable $ natPairs
+        bigMap2 = OldMap.fromFoldable $ natPairs2
+        bigMap' = M.fromFoldable $ natPairs
+        bigMap2' = M.fromFoldable $ natPairs2
+    
+    log $ "OldMap.union: big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> OldMap.union bigMap bigMap2
+
+    log $ "M.union: big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> M.union bigMap' bigMap2'
 
   benchSize = do
     let nats = L.range 0 999999
@@ -42,6 +74,48 @@ benchMap = do
 
     log $ "size: big map (" <> show (M.size bigMap) <> ")"
     benchWith 10  \_ -> M.size bigMap
+
+  benchFoldable = do
+    let nats = L.range 0 999999
+        natPairs = (\x -> Tuple x x) <$> nats
+        bigMap = OldMap.fromFoldable $ natPairs
+        bigMap' = M.fromFoldable $ natPairs
+
+    log $ "OldMap.foldr big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> F.foldr (+) 0 bigMap
+
+    log $ "M.foldr big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> F.foldr (+) 0 bigMap'
+
+    log $ "OldMap.foldl big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> F.foldl (+) 0 bigMap
+
+    log $ "M.foldl big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> F.foldl (+) 0 bigMap'
+
+    log $ "OldMap.foldMap big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> F.foldMap Additive bigMap
+
+    log $ "M.foldMap big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> F.foldMap Additive bigMap'
+
+    log $ "OldMap.foldrWithIndex big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap
+
+    log $ "M.foldrWithIndex big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap'
+
+    log $ "OldMap.foldlWithIndex big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap
+
+    log $ "M.foldlWithIndex big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap'
+
+    log $ "OldMap.foldMapWithIndex big map (" <> show (OldMap.size bigMap) <> ")"
+    benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap
+
+    log $ "M.foldMapWithIndex big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap'
 
   benchFromFoldable = do
     let natStrs = show <$> L.range 0 99999

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -11,7 +11,6 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Console (log)
 import Performance.Minibench (bench, benchWith)
-import Data.Monoid.Additive (Additive(..))
 
 benchMap :: Effect Unit
 benchMap = do
@@ -79,47 +78,47 @@ benchMap = do
 
   benchFoldable = do
     let nats = L.range 0 999999
-        natPairs = (\x -> Tuple x x) <$> nats
+        natPairs = (flip Tuple) unit <$> nats
         bigMap = Map2a0bff.fromFoldable $ natPairs
         bigMap' = M.fromFoldable $ natPairs
         size = Map2a0bff.size bigMap
         size' = M.size bigMap'
 
     log $ "Map2a0bff.foldr big map (" <> show size <> ")"
-    benchWith 10 \_ -> F.foldr (+) 0 bigMap
+    benchWith 10 \_ -> F.foldr (\_ _ -> unit) unit bigMap
 
     log $ "M.foldr big map (" <> show size' <> ")"
-    benchWith 10 \_ -> F.foldr (+) 0 bigMap'
+    benchWith 10 \_ -> F.foldr (\_ _ -> unit) unit bigMap'
 
     log $ "Map2a0bff.foldl big map (" <> show size <> ")"
-    benchWith 10 \_ -> F.foldl (+) 0 bigMap
+    benchWith 10 \_ -> F.foldl (\_ _ -> unit) unit bigMap
 
     log $ "M.foldl big map (" <> show size' <> ")"
-    benchWith 10 \_ -> F.foldl (+) 0 bigMap'
+    benchWith 10 \_ -> F.foldl (\_ _ -> unit) unit bigMap'
 
     log $ "Map2a0bff.foldMap big map (" <> show size <> ")"
-    benchWith 10 \_ -> F.foldMap Additive bigMap
+    benchWith 10 \_ -> F.foldMap (\_ -> unit) bigMap
 
     log $ "M.foldMap big map (" <> show size' <> ")"
-    benchWith 10 \_ -> F.foldMap Additive bigMap'
+    benchWith 10 \_ -> F.foldMap (\_ -> unit) bigMap'
 
     log $ "Map2a0bff.foldrWithIndex big map (" <> show size <> ")"
-    benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap
+    benchWith 10 \_ -> FI.foldrWithIndex (\_ _ _ -> unit) unit bigMap
 
     log $ "M.foldrWithIndex big map (" <> show size' <> ")"
-    benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap'
+    benchWith 10 \_ -> FI.foldrWithIndex (\_ _ _ -> unit) unit bigMap'
 
     log $ "Map2a0bff.foldlWithIndex big map (" <> show size <> ")"
-    benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap
+    benchWith 10 \_ -> FI.foldlWithIndex (\_ _ _ -> unit) unit bigMap
 
     log $ "M.foldlWithIndex big map (" <> show size' <> ")"
-    benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap'
+    benchWith 10 \_ -> FI.foldlWithIndex (\_ _ _ -> unit) unit bigMap'
 
     log $ "Map2a0bff.foldMapWithIndex big map (" <> show size <> ")"
-    benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap
+    benchWith 10 \_ -> FI.foldMapWithIndex (\_ _ -> unit) bigMap
 
     log $ "M.foldMapWithIndex big map (" <> show size' <> ")"
-    benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap'
+    benchWith 10 \_ -> FI.foldMapWithIndex (\_ _ -> unit) bigMap'
 
   benchFromFoldable = do
     let natStrs = show <$> L.range 0 99999

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.List as L
 import Data.Map as M
-import Bench.OldMap as OldMap
+import Bench.Data.Map2a0bff as Map2a0bff
 import Data.Foldable as F
 import Data.FoldableWithIndex as FI
 import Data.Tuple (Tuple(..))
@@ -44,15 +44,17 @@ benchMap = do
         nats2 = L.range 999999 1999999
         natPairs = (flip Tuple) unit <$> nats
         natPairs2 = (flip Tuple) unit <$> nats2
-        bigMap = OldMap.fromFoldable $ natPairs
-        bigMap2 = OldMap.fromFoldable $ natPairs2
+        bigMap = Map2a0bff.fromFoldable $ natPairs
+        bigMap2 = Map2a0bff.fromFoldable $ natPairs2
         bigMap' = M.fromFoldable $ natPairs
         bigMap2' = M.fromFoldable $ natPairs2
+        size = Map2a0bff.size bigMap
+        size' = M.size bigMap'
     
-    log $ "OldMap.union: big map (" <> show (OldMap.size bigMap) <> ")"
-    benchWith 10 \_ -> OldMap.union bigMap bigMap2
+    log $ "Map2a0bff.union: big map (" <> show size <> ")"
+    benchWith 10 \_ -> Map2a0bff.union bigMap bigMap2
 
-    log $ "M.union: big map (" <> show (M.size bigMap') <> ")"
+    log $ "M.union: big map (" <> show size' <> ")"
     benchWith 10 \_ -> M.union bigMap' bigMap2'
 
   benchSize = do
@@ -78,42 +80,42 @@ benchMap = do
   benchFoldable = do
     let nats = L.range 0 999999
         natPairs = (\x -> Tuple x x) <$> nats
-        bigMap = OldMap.fromFoldable $ natPairs
+        bigMap = Map2a0bff.fromFoldable $ natPairs
         bigMap' = M.fromFoldable $ natPairs
-        size = OldMap.size bigMap
+        size = Map2a0bff.size bigMap
         size' = M.size bigMap'
 
-    log $ "OldMap.foldr big map (" <> show size <> ")"
+    log $ "Map2a0bff.foldr big map (" <> show size <> ")"
     benchWith 10 \_ -> F.foldr (+) 0 bigMap
 
     log $ "M.foldr big map (" <> show size' <> ")"
     benchWith 10 \_ -> F.foldr (+) 0 bigMap'
 
-    log $ "OldMap.foldl big map (" <> show size <> ")"
+    log $ "Map2a0bff.foldl big map (" <> show size <> ")"
     benchWith 10 \_ -> F.foldl (+) 0 bigMap
 
     log $ "M.foldl big map (" <> show size' <> ")"
     benchWith 10 \_ -> F.foldl (+) 0 bigMap'
 
-    log $ "OldMap.foldMap big map (" <> show size <> ")"
+    log $ "Map2a0bff.foldMap big map (" <> show size <> ")"
     benchWith 10 \_ -> F.foldMap Additive bigMap
 
     log $ "M.foldMap big map (" <> show size' <> ")"
     benchWith 10 \_ -> F.foldMap Additive bigMap'
 
-    log $ "OldMap.foldrWithIndex big map (" <> show size <> ")"
+    log $ "Map2a0bff.foldrWithIndex big map (" <> show size <> ")"
     benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap
 
     log $ "M.foldrWithIndex big map (" <> show size' <> ")"
     benchWith 10 \_ -> FI.foldrWithIndex (\k v a -> k + a + v) 0 bigMap'
 
-    log $ "OldMap.foldlWithIndex big map (" <> show size <> ")"
+    log $ "Map2a0bff.foldlWithIndex big map (" <> show size <> ")"
     benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap
 
     log $ "M.foldlWithIndex big map (" <> show size' <> ")"
     benchWith 10 \_ -> FI.foldlWithIndex (\k a v -> k + a + v) 0 bigMap'
 
-    log $ "OldMap.foldMapWithIndex big map (" <> show size <> ")"
+    log $ "Map2a0bff.foldMapWithIndex big map (" <> show size <> ")"
     benchWith 10 \_ -> FI.foldMapWithIndex (\i v -> Additive i <> Additive v) bigMap
 
     log $ "M.foldMapWithIndex big map (" <> show size' <> ")"

--- a/bench/Bench/Data/Map2a0bff.purs
+++ b/bench/Bench/Data/Map2a0bff.purs
@@ -1,7 +1,7 @@
 -- | This module defines a type of maps as balanced 2-3 trees, based on
 -- | <http://www.cs.princeton.edu/~dpw/courses/cos326-12/ass/2-3-trees.pdf>
 
-module Bench.OldMap
+module Bench.Data.Map2a0bff
   ( Map(..)
   , showTree
   , empty

--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -136,8 +136,8 @@ instance foldableMap :: Foldable (Map k) where
     Three ml _ v1 mm _ v2 mr -> foldr f (f v1 (foldr f (f v2 (foldr f z mr)) mm)) ml
   foldl f z m = case m of
     Leaf -> z
-    Two ml _ v mr -> foldl f (foldl f (f z v) ml) mr
-    Three ml _ v1 mm _ v2 mr -> foldl f (foldl f (f (foldl f (f z v1) ml) v2) mm) mr
+    Two ml _ v mr -> foldl f (f (foldl f z ml) v) mr
+    Three ml _ v1 mm _ v2 mr -> foldl f (f (foldl f (f (foldl f z ml) v1) mm) v2) mr
   foldMap f m = case m of
     Leaf -> mempty
     Two ml _ v mr -> foldMap f ml <> f v <> foldMap f mr
@@ -150,8 +150,8 @@ instance foldableWithIndexMap :: FoldableWithIndex k (Map k) where
     Three ml k1 v1 mm k2 v2 mr -> foldrWithIndex f (f k1 v1 (foldrWithIndex f (f k2 v2 (foldrWithIndex f z mr)) mm)) ml
   foldlWithIndex f z m = case m of
     Leaf -> z
-    Two ml k v mr -> foldlWithIndex f (foldlWithIndex f (f k z v) ml) mr
-    Three ml k1 v1 mm k2 v2 mr -> foldlWithIndex f (foldlWithIndex f (f k2 (foldlWithIndex f (f k1 z v1) ml) v2) mm) mr
+    Two ml k v mr -> foldlWithIndex f (f k (foldlWithIndex f z ml) v) mr
+    Three ml k1 v1 mm k2 v2 mr -> foldlWithIndex f (f k2 (foldlWithIndex f (f k1 (foldlWithIndex f z ml) v1) mm) v2) mr
   foldMapWithIndex f m = case m of
     Leaf -> mempty
     Two ml k v mr -> foldMapWithIndex f ml <> f k v <> foldMapWithIndex f mr


### PR DESCRIPTION
Here benchmark results

```
Map
===
size
---------------
size: singleton map
mean   = 1.19 μs
stddev = 2.68 μs
min    = 913.00 ns
max    = 71.86 μs
size: small map (100)
mean   = 6.88 μs
stddev = 34.59 μs
min    = 2.28 μs
max    = 717.62 μs
size: midsize map (10000)
mean   = 211.21 μs
stddev = 137.90 μs
min    = 180.70 μs
max    = 1.52 ms
size: big map (1000000)
mean   = 28.68 ms
stddev = 3.98 ms
min    = 24.48 ms
max    = 34.28 ms

fromFoldable
------------
fromFoldable (10000)
mean   = 29.06 ms
stddev = 7.18 ms
min    = 20.62 ms
max    = 59.13 ms
fromFoldable (100000)
mean   = 383.63 ms
stddev = 26.92 ms
min    = 361.95 ms
max    = 451.72 ms

Foldable
---------------
OldMap.foldr big map (1000000)
mean   = 2.74 s
stddev = 583.45 ms
min    = 2.09 s
max    = 3.85 s
M.foldr big map (1000000)
mean   = 136.92 ms
stddev = 8.55 ms
min    = 128.06 ms
max    = 158.92 ms
OldMap.foldl big map (1000000)
mean   = 3.00 s
stddev = 366.36 ms
min    = 2.30 s
max    = 3.68 s
M.foldl big map (1000000)
mean   = 123.67 ms
stddev = 6.86 ms
min    = 116.96 ms
max    = 140.11 ms
OldMap.foldMap big map (1000000)
mean   = 3.32 s
stddev = 353.55 ms
min    = 2.90 s
max    = 3.96 s
M.foldMap big map (1000000)
mean   = 159.57 ms
stddev = 34.20 ms
min    = 116.21 ms
max    = 211.96 ms
OldMap.foldrWithIndex big map (1000000)
mean   = 988.81 ms
stddev = 162.38 ms
min    = 787.27 ms
max    = 1.34 s
M.foldrWithIndex big map (1000000)
mean   = 112.77 ms
stddev = 28.10 ms
min    = 82.08 ms
max    = 158.50 ms
OldMap.foldlWithIndex big map (1000000)
mean   = 810.71 ms
stddev = 120.55 ms
min    = 718.71 ms
max    = 1.13 s
M.foldlWithIndex big map (1000000)
mean   = 82.17 ms
stddev = 4.74 ms
min    = 77.97 ms
max    = 92.23 ms
OldMap.foldMapWithIndex big map (1000000)
mean   = 711.59 ms
stddev = 62.09 ms
min    = 617.76 ms
max    = 820.32 ms
M.foldMapWithIndex big map (1000000)
mean   = 250.51 ms
stddev = 32.33 ms
min    = 198.14 ms
max    = 282.25 ms

union
---------------
OldMap.union: big map (1000000)
mean   = 5.24 s
stddev = 526.87 ms
min    = 4.74 s
max    = 6.54 s
M.union: big map (1000000)
mean   = 4.62 s
stddev = 284.55 ms
min    = 4.28 s
max    = 5.04 s
```