### PR TITLE
Change `values` to use `foldr` for improved speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Breaking changes:
 New features:
 - Exported `Data.Map.Internal` data constructors (#52 by @natefaubion)
 - Add unbiased `Semigroup`/`Monoid` instances to `Map` with `Warn` (#54 by @JordanMartinez)
-- Improved speed of `foldr`, `foldl`, `foldMap`, `foldlWithIndex`, `foldrWithIndex`, `foldMapWithIndex`, `unionWith` (#60 by @xgrommx)
+- Improved speed of `foldr`, `foldl`, `foldMap`, `foldlWithIndex`, `foldrWithIndex`, `foldMapWithIndex`, `unionWith`, and `values` (#60 by @xgrommx, #61 by @JordanMartinez)
 
 Bugfixes:
 

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -36,6 +36,12 @@ benchMap = do
   log "---------------"
   benchUnion
 
+  log ""
+
+  log "values"
+  log "---------------"
+  benchValues
+
   where
 
   benchUnion = do
@@ -55,6 +61,20 @@ benchMap = do
 
     log $ "M.union: big map (" <> show size' <> ")"
     benchWith 10 \_ -> M.union bigMap' bigMap2'
+
+  benchValues = do
+    let nats = L.range 0 999999
+        natPairs = (flip Tuple) unit <$> nats
+        bigMap = Map2a0bff.fromFoldable $ natPairs
+        bigMap' = M.fromFoldable $ natPairs
+        size = Map2a0bff.size bigMap
+        size' = M.size bigMap'
+
+    log $ "Map2a0bff.values: big map (" <> show size <> ")"
+    benchWith 10 \_ -> Map2a0bff.values bigMap
+
+    log $ "M.values: big map (" <> show size' <> ")"
+    benchWith 10 \_ -> M.values bigMap'
 
   benchSize = do
     let nats = L.range 0 999999

--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -657,9 +657,7 @@ keys (Three left k1 _ mid k2 _ right) = keys left <> pure k1 <> keys mid <> pure
 
 -- | Get a list of the values contained in a map
 values :: forall k v. Map k v -> List v
-values Leaf = Nil
-values (Two left _ v right) = values left <> pure v <> values right
-values (Three left _ v1 mid _ v2 right) = values left <> pure v1 <> values mid <> pure v2 <> values right
+values = foldr Cons Nil
 
 -- | Compute the union of two maps, using the specified function
 -- | to combine values for duplicate keys.


### PR DESCRIPTION
**Description of the change**

Since this implementation does not traverse through an intermediary list multiple times, it is must faster.

Fixes the work described in this comment: https://github.com/purescript/purescript-ordered-collections/pull/60#discussion_r855604994=

```
Map
===
values
---------------
Map2a0bff.values: big map (1000000)
mean   = 2.89 s
stddev = 302.43 ms
min    = 2.52 s
max    = 3.43 s
M.values: big map (1000000)
mean   = 278.44 ms
stddev = 4.57 ms
min    = 271.75 ms
max    = 287.72 ms
```

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
