### PR TITLE
Speed up `keys` by using foldrWithIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Breaking changes:
 New features:
 - Exported `Data.Map.Internal` data constructors (#52 by @natefaubion)
 - Add unbiased `Semigroup`/`Monoid` instances to `Map` with `Warn` (#54 by @JordanMartinez)
-- Improved speed of `foldr`, `foldl`, `foldMap`, `foldlWithIndex`, `foldrWithIndex`, `foldMapWithIndex`, `unionWith`, and `values` (#60 by @xgrommx, #61 by @JordanMartinez)
+- Improved speed of `foldr`, `foldl`, `foldMap`, `foldlWithIndex`, `foldrWithIndex`, `foldMapWithIndex`, `unionWith`, `keys` and `values` (#60 by @xgrommx, #61 and #62 by @JordanMartinez)
 
 Bugfixes:
 

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -46,7 +46,7 @@ benchMap = do
 
   log "keys"
   log "---------------"
-  benchValues
+  benchKeys
 
   where
 

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -42,6 +42,12 @@ benchMap = do
   log "---------------"
   benchValues
 
+  log ""
+
+  log "keys"
+  log "---------------"
+  benchValues
+
   where
 
   benchUnion = do
@@ -75,6 +81,20 @@ benchMap = do
 
     log $ "M.values: big map (" <> show size' <> ")"
     benchWith 10 \_ -> M.values bigMap'
+
+  benchKeys = do
+    let nats = L.range 0 999999
+        natPairs = (flip Tuple) unit <$> nats
+        bigMap = Map2a0bff.fromFoldable $ natPairs
+        bigMap' = M.fromFoldable $ natPairs
+        size = Map2a0bff.size bigMap
+        size' = M.size bigMap'
+
+    log $ "Map2a0bff.keys: big map (" <> show size <> ")"
+    benchWith 10 \_ -> Map2a0bff.keys bigMap
+
+    log $ "M.keys: big map (" <> show size' <> ")"
+    benchWith 10 \_ -> M.keys bigMap'
 
   benchSize = do
     let nats = L.range 0 999999

--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -651,9 +651,7 @@ toUnfoldableUnordered m = unfoldr go (m : Nil) where
 
 -- | Get a list of the keys contained in a map
 keys :: forall k v. Map k v -> List k
-keys Leaf = Nil
-keys (Two left k _ right) = keys left <> pure k <> keys right
-keys (Three left k1 _ mid k2 _ right) = keys left <> pure k1 <> keys mid <> pure k2 <> keys right
+keys = foldrWithIndex (\k _ acc -> k : acc) Nil
 
 -- | Get a list of the values contained in a map
 values :: forall k v. Map k v -> List v


### PR DESCRIPTION
**Description of the change**

Addresses the comment raised by @xgrommx here: https://github.com/purescript/purescript-ordered-collections/pull/61#issuecomment-1106612371=
```
Map
===
keys
---------------
Map2a0bff.keys: big map (1000000)
mean   = 2.64 s
stddev = 199.37 ms
min    = 2.39 s
max    = 2.96 s
M.keys: big map (1000000)
mean   = 218.74 ms
stddev = 34.92 ms
min    = 194.87 ms
max    = 301.29 ms
```

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
