### PR TITLE
Use a single fold for difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Speed up `difference` by using 1 fold instead of 2 (#64 by @JordanMartinez)
 
 ## [v3.0.0](https://github.com/purescript/purescript-ordered-collections/releases/tag/v3.0.0) - 2022-04-27
 

--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -48,6 +48,10 @@ benchMap = do
   log "---------------"
   benchKeys
 
+  log "difference"
+  log "---------------"
+  benchDifference
+
   where
 
   benchUnion = do
@@ -61,7 +65,7 @@ benchMap = do
         bigMap2' = M.fromFoldable $ natPairs2
         size = Map2a0bff.size bigMap
         size' = M.size bigMap'
-    
+
     log $ "Map2a0bff.union: big map (" <> show size <> ")"
     benchWith 10 \_ -> Map2a0bff.union bigMap bigMap2
 
@@ -170,3 +174,32 @@ benchMap = do
 
     log $ "fromFoldable (" <> show (L.length natPairs) <> ")"
     benchWith 10 \_ -> M.fromFoldable natPairs
+
+  benchDifference = do
+    let nats = L.range 0 999999
+        natPairs = (flip Tuple) unit <$> nats
+        singletonMap = M.singleton 0 unit
+        smallMap = Map2a0bff.fromFoldable $ L.take 100 natPairs
+        smallMap' = M.fromFoldable $ L.take 100 natPairs
+        midMap = Map2a0bff.fromFoldable $ L.take 10000 natPairs
+        midMap' = M.fromFoldable $ L.take 10000 natPairs
+        bigMap = Map2a0bff.fromFoldable $ natPairs
+        bigMap' = M.fromFoldable $ natPairs
+
+    log $ "Map2a0bff.difference: small map (" <> show (Map2a0bff.size smallMap) <> ")"
+    bench \_ -> Map2a0bff.difference smallMap midMap
+
+    log $ "M.difference: small map (" <> show (M.size smallMap') <> ")"
+    bench \_ -> M.difference smallMap' midMap'
+
+    log $ "Map2a0bff.difference: midsize map (" <> show (Map2a0bff.size midMap) <> ")"
+    benchWith 100 \_ -> Map2a0bff.difference midMap midMap
+
+    log $ "M.difference: midsize map (" <> show (M.size midMap') <> ")"
+    benchWith 100 \_ -> M.difference midMap' midMap'
+
+    log $ "Map2a0bff.difference: big map (" <> show (Map2a0bff.size bigMap) <> ")"
+    benchWith 10  \_ -> Map2a0bff.difference bigMap midMap
+
+    log $ "M.difference: big map (" <> show (M.size bigMap') <> ")"
+    benchWith 10  \_ -> M.difference bigMap' midMap'

--- a/src/Data/Map/Internal.purs
+++ b/src/Data/Map/Internal.purs
@@ -694,7 +694,7 @@ intersection = intersectionWith const
 -- | Difference of two maps. Return elements of the first map where
 -- | the keys do not exist in the second map.
 difference :: forall k v w. Ord k => Map k v -> Map k w -> Map k v
-difference m1 m2 = foldl (flip delete) m1 (keys m2)
+difference m1 m2 = foldlWithIndex (\k m _ -> delete k m) m1 m2
 
 -- | Test whether one map contains all of the keys and values contained in another map
 isSubmap :: forall k v. Ord k => Eq v => Map k v -> Map k v -> Boolean


### PR DESCRIPTION
**Description of the change**

Uses a single fold for `difference` rather than folding over `m2` once to produce a list and then folding over that list a second time to do the deletion.

Benchmark below:
```
Map
===
difference
---------------
Map2a0bff.difference: small map (100)
mean   = 17.89 ms
stddev = 1.37 ms
min    = 16.17 ms
max    = 40.21 ms
M.difference: small map (100)
mean   = 2.43 ms
stddev = 921.62 μs
min    = 1.84 ms
max    = 18.75 ms
Map2a0bff.difference: midsize map (10000)
mean   = 54.24 ms
stddev = 939.99 μs
min    = 53.27 ms
max    = 57.81 ms
M.difference: midsize map (10000)
mean   = 32.48 ms
stddev = 6.42 ms
min    = 24.70 ms
max    = 50.55 ms
Map2a0bff.difference: big map (1000000)
mean   = 65.23 ms
stddev = 3.98 ms
min    = 60.30 ms
max    = 72.10 ms
M.difference: big map (1000000)
mean   = 48.51 ms
stddev = 4.39 ms
min    = 45.34 ms
max    = 60.00 ms
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
